### PR TITLE
Fix port index calculation.

### DIFF
--- a/fasm2bels/lib/interchange_capnp.py
+++ b/fasm2bels/lib/interchange_capnp.py
@@ -297,7 +297,7 @@ def output_logical_netlist(logical_netlist_schema,
             cell_obj.init('ports', len(cell.ports))
             for idx, (port_name, port) in enumerate(cell.ports.items()):
                 port_idx, port_obj = logical_netlist.next_port()
-                ports[cell.name, port_name] = port_idx
+                ports[cell.name, port_name] = (port_idx, port)
                 cell_obj.ports[idx] = port_idx
 
                 port_obj.dir = logical_netlist_schema.Netlist.Direction.__dict__[
@@ -357,16 +357,17 @@ def output_logical_netlist(logical_netlist_schema,
                         instance_cell_name = cell.cell_instances[
                             port.instance_name].cell_name
                         port_obj.inst = cell_instances[port.instance_name]
-                        port_obj.port = ports[instance_cell_name, port.name]
+                        port_obj.port, port_pyobj = ports[instance_cell_name,
+                                                          port.name]
                     else:
                         # If port.instance_name is None, then this is a cell
                         # port connection
                         port_obj.extPort = None
-                        port_obj.port = ports[cell.name, port.name]
+                        port_obj.port, port_pyobj = ports[cell.name, port.name]
 
                     # Handle bussed port annotations
                     if port.idx is not None:
-                        port_obj.busIdx.idx = port.idx
+                        port_obj.busIdx.idx = port_pyobj.encode_index(port.idx)
                     else:
                         port_obj.busIdx.singleBit = None
 

--- a/fasm2bels/lib/interchange_capnp.py
+++ b/fasm2bels/lib/interchange_capnp.py
@@ -736,12 +736,15 @@ def output_interchange(top, capnp_folder, part, f_logical, f_physical, f_xdc):
                     ports[port] = (direction, width)
 
             # Add instances of unconnected ports (as needed).
-            for port, is_output in instance.port_direction.items():
+            for port, direction in instance.port_direction.items():
                 width = instance.port_width[port]
 
-                if is_output:
+                if direction == "output":
                     direction = Direction.Output
+                elif direction == "inout":
+                    direction = Direction.Inout
                 else:
+                    assert direction == "input", direction
                     direction = Direction.Input
 
                 if port in ports:

--- a/fasm2bels/lib/logical_netlist.py
+++ b/fasm2bels/lib/logical_netlist.py
@@ -1,6 +1,7 @@
 import enum
 from collections import namedtuple
 
+
 # Declares a port on a cell, which is bit or a bus.
 #
 # If the port is a bit, then bus should be None.
@@ -10,7 +11,30 @@ from collections import namedtuple
 #
 # property_map should be a dict with str keys, and the values can be str,
 # int or bool.
-Port = namedtuple('Port', 'direction property_map bus')
+class Port(namedtuple('Port', 'direction property_map bus')):
+    def encode_index(self, index):
+        """ Encode slice index into bus index.
+
+        A bus defined as [3:0] has a width of 4.  The bus index is the
+        distance from the start (e.g. 3) to the end (e.g. 0).
+
+        So ex[3] is bus index 0, ex[2] is bus index 1, etc.
+
+        A bus defined as [0:3] has a width of 4 too, However ex[3] is now bus 
+        index 3, etc.
+
+        """
+        assert self.bus is not None
+
+        if self.bus.start <= self.bus.end:
+            assert index >= self.bus.start
+            assert index <= self.bus.end
+            return index - self.bus.start
+        else:
+            assert index >= self.bus.end
+            assert index <= self.bus.start
+            return self.bus.start - index
+
 
 # Bus range for a port.
 #

--- a/fasm2bels/models/bram_models.py
+++ b/fasm2bels/models/bram_models.py
@@ -1136,32 +1136,32 @@ def process_bram36_site(top, features, set_features):
             pin_name = '{}[{}]'.format(output_wire, idx)
             site.add_source(bel, pin_name, wire_name, bel.bel, wire_name)
 
-    bel.add_unconnected_port('INJECTSBITERR', None, output=False)
+    bel.add_unconnected_port('INJECTSBITERR', None, direction="input")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'INJECTSBITERR', 'INJECTSBITERR')
-    bel.add_unconnected_port('INJECTDBITERR', None, output=False)
+    bel.add_unconnected_port('INJECTDBITERR', None, direction="input")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'INJECTDBITERR', 'INJECTDBITERR')
 
-    bel.add_unconnected_port('SBITERR', None, output=True)
+    bel.add_unconnected_port('SBITERR', None, direction="output")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'SBITERR', 'SBITERR')
-    bel.add_unconnected_port('DBITERR', None, output=True)
+    bel.add_unconnected_port('DBITERR', None, direction="output")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'DBITERR', 'DBITERR')
 
-    bel.add_unconnected_port('CASCADEINA', None, output=False)
+    bel.add_unconnected_port('CASCADEINA', None, direction="input")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'CASCADEINA', 'CASCADEINA')
-    bel.add_unconnected_port('CASCADEINB', None, output=False)
+    bel.add_unconnected_port('CASCADEINB', None, direction="input")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'CASCADEINB', 'CASCADEINB')
 
-    bel.add_unconnected_port('CASCADEOUTA', None, output=True)
+    bel.add_unconnected_port('CASCADEOUTA', None, direction="output")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'CASCADEOUTA', 'CASCADEOUTA')
-    bel.add_unconnected_port('CASCADEOUTB', None, output=True)
+    bel.add_unconnected_port('CASCADEOUTB', None, direction="output")
     bel.map_bel_pin_to_cell_pin(bel.bel, 'CASCADEOUTB', 'CASCADEOUTB')
 
-    bel.add_unconnected_port('ECCPARITY', 8, output=True)
+    bel.add_unconnected_port('ECCPARITY', 8, direction="output")
     for idx in range(8):
         bel.map_bel_pin_to_cell_pin(bel.bel, 'ECCPARITY{}'.format(idx),
                                     'ECCPARITY[{}]'.format(idx))
 
-    bel.add_unconnected_port('RDADDRECC', 9, output=True)
+    bel.add_unconnected_port('RDADDRECC', 9, direction="output")
     for idx in range(9):
         bel.map_bel_pin_to_cell_pin(bel.bel, 'RDADDRECC{}'.format(idx),
                                     'RDADDRECC[{}]'.format(idx))

--- a/fasm2bels/models/clb_models.py
+++ b/fasm2bels/models/clb_models.py
@@ -1044,7 +1044,8 @@ def process_slice(top, s):
                         site.add_internal_source(
                             srl, 'Q31', '{}MC31'.format(row), srl.bel, 'MC31')
                     else:
-                        srl.add_unconnected_port('Q31', None, output=True)
+                        srl.add_unconnected_port(
+                            'Q31', None, direction="output")
 
                     site.add_bel(srl, name='{}6SRL_32'.format(row))
 

--- a/fasm2bels/models/cmt_models.py
+++ b/fasm2bels/models/cmt_models.py
@@ -185,7 +185,7 @@ def process_pll(conn, top, tile_name, features):
                 pll.parameters['CLK{}_PHASE'.format(
                     clkout)] = "{0:.3f}".format(phase)
         else:
-            pll.add_unconnected_port('CLK' + clkout, None, output=True)
+            pll.add_unconnected_port('CLK' + clkout, None, direction="output")
             pll.map_bel_pin_to_cell_pin(
                 bel_name=pll.bel,
                 bel_pin='CLK' + clkout,

--- a/fasm2bels/models/ioi_models.py
+++ b/fasm2bels/models/ioi_models.py
@@ -158,8 +158,8 @@ def process_idelay(top, features):
         # Adding sources
         site.add_source(bel, 'DATAOUT', 'DATAOUT', bel.bel, 'DATAOUT')
 
-        bel.add_unconnected_port('CNTVALUEIN', 5, output=False)
-        bel.add_unconnected_port('CNTVALUEOUT', 5, output=True)
+        bel.add_unconnected_port('CNTVALUEIN', 5, direction="input")
+        bel.add_unconnected_port('CNTVALUEOUT', 5, direction="output")
 
         for i in range(5):
             bel.map_bel_pin_to_cell_pin(
@@ -281,7 +281,7 @@ def process_iserdes(top, site, idelay_site=None):
             or idelay_site.has_feature("ZIDELAY_VALUE")):
         site.add_sink(bel, 'DDLY', 'DDLY', bel.bel, 'DDLY')
 
-        bel.add_unconnected_port('D', None, output=False)
+        bel.add_unconnected_port('D', None, direction="input")
         bel.map_bel_pin_to_cell_pin(bel.bel, 'D', 'D')
     else:
         site.add_sink(
@@ -292,7 +292,7 @@ def process_iserdes(top, site, idelay_site=None):
             'D',
             site_pips=make_inverter_path('D', bel.parameters['IS_D_INVERTED']))
 
-        bel.add_unconnected_port('DDLY', None, output=False)
+        bel.add_unconnected_port('DDLY', None, direction="input")
         bel.map_bel_pin_to_cell_pin(bel.bel, 'DDLY', 'DDLY')
 
     for i in range(1, 9):
@@ -308,11 +308,11 @@ def process_iserdes(top, site, idelay_site=None):
     for unused_in in [
             'SHIFTIN1', 'SHIFTIN2', 'OFB', 'OCLK', 'OCLKB', 'CLKDIVP'
     ]:
-        bel.add_unconnected_port(unused_in, None, output=False)
+        bel.add_unconnected_port(unused_in, None, direction="input")
         bel.map_bel_pin_to_cell_pin(bel.bel, unused_in, unused_in)
 
     for unused_out in ['SHIFTOUT1', 'SHIFTOUT2']:
-        bel.add_unconnected_port(unused_out, None, output=True)
+        bel.add_unconnected_port(unused_out, None, direction="output")
         bel.map_bel_pin_to_cell_pin(bel.bel, unused_out, unused_out)
 
     site.add_bel(bel)
@@ -474,10 +474,10 @@ def process_oddr_oq(top, site):
     # Determine whether we have SET or RESET
     if site.has_feature('ZSRVAL_OQ'):
         site.add_sink(bel, 'R', 'SR', bel.bel, 'SR')
-        bel.add_unconnected_port('S', None, output=False)
+        bel.add_unconnected_port('S', None, direction="input")
     else:
         site.add_sink(bel, 'S', 'SR', bel.bel, 'SR')
-        bel.add_unconnected_port('R', None, output=False)
+        bel.add_unconnected_port('R', None, direction="input")
 
     # DDR_CLK_EDGE
     if site.has_feature('ODDR.DDR_CLK_EDGE.SAME_EDGE'):
@@ -670,11 +670,11 @@ def process_oserdes(top, site):
     bel.parameters["SRVAL_TQ"] = "0" if site.has_feature('ZSRVAL_TQ') else "1"
 
     for unused_in in ['SHIFTIN1', 'SHIFTIN2', 'TBYTEIN']:
-        bel.add_unconnected_port(unused_in, None, output=False)
+        bel.add_unconnected_port(unused_in, None, direction="input")
         bel.map_bel_pin_to_cell_pin(bel.bel, unused_in, unused_in)
 
     for unused_out in ['SHIFTOUT1', 'SHIFTOUT2', 'TBYTEOUT', 'OFB', 'TFB']:
-        bel.add_unconnected_port(unused_out, None, output=True)
+        bel.add_unconnected_port(unused_out, None, direction="output")
         bel.map_bel_pin_to_cell_pin(bel.bel, unused_out, unused_out)
 
     site.add_bel(bel)

--- a/fasm2bels/models/pss_models.py
+++ b/fasm2bels/models/pss_models.py
@@ -45,6 +45,14 @@ def insert_ps7(top, pss_tile, ps7_site, ps7_ports):
 
         # Add only "normal" ports that go to the PL.
         if port["class"] != "normal":
+            if port["class"] in ["mio"]:
+                if port["width"] == 1:
+                    bel.add_unconnected_port(
+                        name, width=None, direction=port["direction"])
+                else:
+                    bel.add_unconnected_port(
+                        name, width=port["width"], direction=port["direction"])
+
             continue
 
         # Choose adder func.

--- a/fasm2bels/models/verilog_modeling.py
+++ b/fasm2bels/models/verilog_modeling.py
@@ -498,7 +498,7 @@ class Bel(object):
         """ Explicitly set the width of a port, in the event that not all bits will be connected. """
         self.port_width[port] = width
 
-    def add_unconnected_port(self, port, width, output):
+    def add_unconnected_port(self, port, width, direction):
         """ Add a port to this cell that is unconnected.
 
         port : str
@@ -508,13 +508,13 @@ class Bel(object):
             For bussed ports, the width of the port, otherwise None for bitty
             ports.
 
-        output : bool
-            Set output to True if this port is an output, otherwise this port
+        direction : str
+            Should be either "input", "output", or "inout".
             is an input.
 
         """
         assert port not in self.connections
-        self.port_direction[port] = output
+        self.port_direction[port] = direction
         self.set_port_width(port, width)
 
     def set_prefix(self, prefix):


### PR DESCRIPTION
Port indices in the logical netlist capnp are distance from bus.start, rather than the slice index.