### PR TITLE
iob: fix differential IOB in_term feature decoding

### DIFF
--- a/fasm2bels/models/iob_models.py
+++ b/fasm2bels/models/iob_models.py
@@ -632,7 +632,7 @@ def process_differential_iob(top, iob, in_diff, out_diff):
 
     # Decode IOSTANDARD parameters
     iostd_in, iostd_out = decode_iostandard_params(site, diff=True)
-    in_term = decode_in_term(site)
+    in_term = decode_in_term(site_s)
 
     # Differential input
     if in_diff and not out_diff:


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes an issue with the IN_TERM features when the IOB is in differential mode.

The in_term feature was not decoded correctly, hence the feature is taken from the IOB33S site instead of the combined IOB33S + IOB33M site.

This PR fixes point 2 in https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1657#issuecomment-708400845