### PR TITLE
clb: latches: invert IS_C_INVERTED when ff is in latch mode

### DIFF
--- a/fasm2bels/models/clb_models.py
+++ b/fasm2bels/models/clb_models.py
@@ -1867,7 +1867,7 @@ def process_slice(top, s):
             ff5.parameters['INIT'] = init
 
             if name in ['LDCE', 'LDPE']:
-                ff5.parameters['IS_G_INVERTED'] = IS_C_INVERTED
+                ff5.parameters['IS_G_INVERTED'] = int(not IS_C_INVERTED)
             else:
                 ff5.parameters['IS_C_INVERTED'] = IS_C_INVERTED
 
@@ -1972,7 +1972,7 @@ def process_slice(top, s):
         ff.parameters['INIT'] = init
 
         if name in ['LDCE', 'LDPE']:
-            ff.parameters['IS_G_INVERTED'] = IS_C_INVERTED
+            ff.parameters['IS_G_INVERTED'] = int(not IS_C_INVERTED)
         else:
             ff.parameters['IS_C_INVERTED'] = IS_C_INVERTED
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

When using latches, the CLKINV feature gets enabled, even though the IS_G_INVERTED is set to zero. This happens on a full-Vivado generated bitstream, therefore, I presume that the CLKINV feature, combined with the LATCH one, enable the latch and do not activate the CLK inverter.

This PR addresses this issue.