### PR TITLE
gh-actions: ci: update clang-format and g++ to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install clang-format-5.0 g++-6 xsltproc git
+        sudo apt-get install clang-format-8 g++-8 xsltproc git
         pip install --upgrade -r requirements.txt
 
     - name: Check formatting


### PR DESCRIPTION
This is the same issue as discussed in https://github.com/SymbiFlow/symbiflow-arch-defs/pull/2109
The [CI is red](https://github.com/SymbiFlow/symbiflow-xc-fasm2bels/pull/50/checks?check_run_id=2142584126#step:4:67) because of this in the [PCIe PR](https://github.com/SymbiFlow/symbiflow-xc-fasm2bels/pull/50)

Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>